### PR TITLE
Add Strict-Transport-Security header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,7 @@ server {
 	gzip_vary on;
 	gzip_min_length 1000;
 	gzip_proxied any;
-	gzip_types text/plain text/css text/xml application/xml text/javascript application/x-javascript;
+	gzip_types text/plain text/css text/xml text/html application/xml text/javascript application/x-javascript;
 	gzip_disable "MSIE [1-6]\.";
 
 	#Forward real ip and host to Plex

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,6 +31,9 @@ server {
 	ssl_dhparam /path/to/dhparam.pem;
 	ssl_ecdh_curve secp384r1;
 
+	#Prevent multiple (possible) redirects from http to https by instructing modern browsers to always use https: https://bjornjohansen.no/optimizing-https-nginx
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
 	#Plex has A LOT of javascript, xml and html. This helps a lot, but if it causes playback issues with devices turn it off. (Haven't encountered any yet)
 	gzip on;
 	gzip_vary on;


### PR DESCRIPTION
Prevent multiple (possible) redirects from http to https by instructing modern browsers to always use https: https://bjornjohansen.no/optimizing-https-nginx