### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This configuration will allow you to run Plex over port 443(HTTPS) with Nginx.
 Nginx
  
 Plex:
-* Remote Access - Manually specify public port = 443
-* Network - Custom server access URLs = https://plex.EXAMPLE.COM:443
+* Remote Access - Disable
+* Network - Custom server access URLs = https://<your-domain>:443
  
 ## Optional Requirements
  
 UFW or other firewall:
-* Deny port 32400 externally (Plex still pings over 32400, some clients may use 32400 dispite 443 being set by mistake).
+* Deny port 32400 externally (Plex still pings over 32400, some clients may use 32400 by mistake despite 443 being set).
  
 CloudFlare:
 * SSL set to at least Full.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nginx
  
 Plex:
 * Remote Access - Disable
-* Network - Custom server access URLs = https://<your-domain>:443
+* Network - Custom server access URLs = `https://<your-domain>:443`
  
 ## Optional Requirements
  


### PR DESCRIPTION
Remote Access is not needed if Plex is put behind our own proxy (_we_ make Plex accessible remotely using our reverse proxy). Disabling this could maybe 'fix' clients still trying to reach Plex on port 32400.

The "Custom server access URL" is important, with that being set correctly it is enough to make Plex accessible remotely.

Based on information from this forum thread: https://forums.plex.tv/discussion/241881/strange-remote-access-behaviour/p1