### PR TITLE
Turn ssl_session_tickets off.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,9 +42,7 @@ server {
 	ssl_stapling_verify on;
 	#For letsencrypt.org you can get your chain like this: https://esham.io/2016/01/ocsp-stapling
 	ssl_trusted_certificate /path/to/chain.pem;
-
-	#Reuse ssl sessions, avoids unnecessary handshakes
-	ssl_session_tickets on;
+	ssl_session_tickets off;
 
 	#Use: openssl dhparam -out dhparam.pem 2048 - 4096 is better but for overhead reasons 2048 is enough for Plex.
 	ssl_dhparam /path/to/dhparam.pem;


### PR DESCRIPTION
Even though session tickets can have performance benefits, it also introduces a security risk: https://wiki.mozilla.org/Security/Server_Side_TLS#TLS_tickets_.28RFC_5077.29

By default it's turned off in the [Mozilla SSL Configuration Generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/).