### PR TITLE
Duplicate MIME type error fix

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -55,7 +55,7 @@ server {
 	gzip_vary on;
 	gzip_min_length 1000;
 	gzip_proxied any;
-	gzip_types text/plain text/html text/css text/xml application/xml text/javascript application/x-javascript image/svg+xml;
+	gzip_types text/plain text/css text/xml application/xml text/javascript application/x-javascript image/svg+xml;
 	gzip_disable "MSIE [1-6]\.";
 
 	#Forward real ip and host to Plex


### PR DESCRIPTION
The ```text/html``` argument for ```gzip_types``` causes an error as it is included by default, something like this:

```2017/04/26 09:53:12 [warn] 11022#11022: duplicate MIME type "text/html" in /etc/nginx/sites-enabled/my.domain.com:56```

The commit included removes the argument, and works fine :)