### PR TITLE
Update to prevent host spoofing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -59,7 +59,7 @@ server {
 	gzip_disable "MSIE [1-6]\.";
 
 	#Forward real ip and host to Plex
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This change updates $http_host to $host to prevent host spoofing.
See more here: https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md