### PR TITLE
client_max_body_size included to fix Camera Upload

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -58,6 +58,10 @@ server {
 	gzip_types text/plain text/html text/css text/xml application/xml text/javascript application/x-javascript image/svg+xml;
 	gzip_disable "MSIE [1-6]\.";
 
+	#Nginx default client_max_body_size is 1MB, which breaks Camera Upload feature from the phones.
+	#Increasing the limit fixes the issue. Anyhow, if 4K videos are expected to be uploaded, the size might need to be increased even more
+	client_max_body_size 100M;
+
 	#Forward real ip and host to Plex
 	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Camera Upload feature stops working if Plex Server is behind a Nginx proxy. This is due to [default maximum body size being set to 1M](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). Since photos on the modern phones are larger than that, they cannot be uploaded and Nginx reports the following error:

> client intended to send too large body

The PR changes `client_max_body_size` to a larger one (100M), so the Camera Upload feature could work.