### PR TITLE
update nginx.conf to block plex news

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -81,6 +81,10 @@ server {
 
 	location / {
 		proxy_pass http://plex_backend;
+	#If you wish to disable PlexNews, install apt install nginx-extras and uncomment the following lines
+	#sub_filter ',news,' ',';
+    	#sub_filter_once on;
+    	#sub_filter_types text/xml;
 	}
 
 	#PlexPy forward example, works the same for other services.

--- a/nginx.conf
+++ b/nginx.conf
@@ -72,6 +72,8 @@ server {
 
 	#Websockets
 	proxy_http_version 1.1;
+        #If you are disabling Plex News, please uncomment the next line 
+        #proxy_set_header Accept-Encoding "";	
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "upgrade";
 
@@ -82,9 +84,9 @@ server {
 	location / {
 		proxy_pass http://plex_backend;
 	#If you wish to disable PlexNews, install apt install nginx-extras and uncomment the following lines
-	#sub_filter ',news,' ',';
-    	#sub_filter_once on;
-    	#sub_filter_types text/xml;
+        #sub_filter ',news,' ',';
+        #sub_filter_once on;
+	#sub_filter_types text/xml;
 	}
 
 	#PlexPy forward example, works the same for other services.


### PR DESCRIPTION
Given people are not comfortable with Plex News, this can disable it on  your end clients without any modifications to the clients. (v1.9.2 PlexServer)