### PR TITLE
Fix incorrect client IP being passed to Plex

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -68,7 +68,7 @@ server {
 	#Forward real ip and host to Plex
 	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header X-Forwarded-For '$http_x_forwarded_for,$realip_remote_addr';
 	proxy_set_header X-Forwarded-Proto $scheme;
 
 	#Websockets


### PR DESCRIPTION
Fix incorrect real IP address being passed to Plex.

If users have the ngx_http_realip_module enabled, the wrong IP address may be passed to Plex and therefore reports the Nginx reverse proxy as the client IP.  Adding $realip_remote_addr fixes this.